### PR TITLE
Update Go version and CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Cache-Go

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/arran4/lookup
 
-go 1.16
+go 1.24
 
 require (
 	github.com/google/go-cmp v0.5.6
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
## Summary
- bump Go version in go.mod to 1.24
- update GitHub Actions test matrix to use Go 1.23 and 1.24 with latest setup-go

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e5b85a894832f891ea857c1bfa623