### PR TITLE
Reorganize documentation and add advanced examples

### DIFF
--- a/examples/advanced/advanced_example.go
+++ b/examples/advanced/advanced_example.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+
+	"github.com/arran4/lookup"
+)
+
+type Node struct {
+	Name     string
+	Size     int
+	Tags     []string
+	Children []*Node
+}
+
+func main() {
+	root := &Node{
+		Name: "root",
+		Size: 3,
+		Tags: []string{"root", "groupA"},
+		Children: []*Node{
+			{Name: "child1", Size: 1, Tags: []string{"groupA"}},
+			{Name: "child2", Size: 2, Tags: []string{"groupB"}},
+		},
+	}
+
+	r := lookup.Reflect(root)
+
+	log.Printf("child names: %#v", r.Find("Children").Find("Name").Raw())
+
+	log.Printf("groupA children: %#v", r.Find("Children",
+		lookup.Filter(lookup.This("Tags").Find("", lookup.Contains(lookup.Constant("groupA"))))).Find("Name").Raw())
+
+	log.Printf("largest child size: %#v",
+		r.Find("Children", lookup.Map(lookup.This("Size")), lookup.Index("-1")).Raw())
+
+	log.Printf("has groupB child: %#v",
+		r.Find("Children", lookup.Any(lookup.Map(lookup.This("Tags").Find("", lookup.Contains(lookup.Constant("groupB")))))).Raw())
+}

--- a/examples/advanced/advanced_example_test.go
+++ b/examples/advanced/advanced_example_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/arran4/lookup"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAdvanced(t *testing.T) {
+	root := &Node{
+		Name: "root",
+		Size: 3,
+		Tags: []string{"root", "groupA"},
+		Children: []*Node{
+			{Name: "child1", Size: 1, Tags: []string{"groupA"}},
+			{Name: "child2", Size: 2, Tags: []string{"groupB"}},
+		},
+	}
+	r := lookup.Reflect(root)
+	assert.Equal(t, []string{"child1", "child2"}, r.Find("Children").Find("Name").Raw())
+	assert.Equal(t, []string{"child1"}, r.Find("Children", lookup.Filter(
+		lookup.This("Tags").Find("", lookup.Contains(lookup.Constant("groupA"))))).Find("Name").Raw())
+	assert.Equal(t, 2, r.Find("Children", lookup.Map(lookup.This("Size")), lookup.Index("-1")).Raw())
+	assert.Equal(t, true, r.Find("Children", lookup.Any(lookup.Map(lookup.This("Tags").Find("", lookup.Contains(lookup.Constant("groupB")))))).Raw())
+}

--- a/examples/basic_example.go
+++ b/examples/basic_example.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+
+	"github.com/arran4/lookup"
+)
+
+type Node struct {
+	Name string
+	Size int
+}
+
+func main() {
+	root := &Node{Name: "root", Size: 10}
+	r := lookup.Reflect(root)
+	log.Printf("name = %s", r.Find("Name").Raw())
+	log.Printf("size = %d", r.Find("Size").Raw())
+}

--- a/examples/basic_example_test.go
+++ b/examples/basic_example_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/arran4/lookup"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBasic(t *testing.T) {
+	root := &Node{Name: "root", Size: 10}
+	r := lookup.Reflect(root)
+	assert.Equal(t, "root", r.Find("Name").Raw())
+	assert.Equal(t, 10, r.Find("Size").Raw())
+}


### PR DESCRIPTION
## Summary
- simplify and restructure README
- document modifiers and advanced usage
- add `examples/advanced` with runnable code

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e5b9c6774832f9920906dfd11b90f