### PR TITLE
Fix comment typo in Interfaceor

### DIFF
--- a/interfaceor.go
+++ b/interfaceor.go
@@ -14,7 +14,7 @@ type Interface interface {
 	Raw() interface{}
 }
 
-// Interfaceor the warping element for the Interface component to make it adhere to the Pathor interface
+// Interfaceor the wrapping element for the Interface component to make it adhere to the Pathor interface
 type Interfaceor struct {
 	i    Interface
 	path string


### PR DESCRIPTION
## Summary
- correct a misspelled phrase in `interfaceor.go`

## Testing
- `gofmt -w interfaceor.go`


------
https://chatgpt.com/codex/tasks/task_e_684e69cb4e40832fadd3efd2c326027a