### PR TITLE
Fix nil element typo in error messages

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -60,7 +60,7 @@ func forEach(scope *Scope, v reflect.Value, ef func(pathor Pathor) error) Pathor
 	case reflect.Array, reflect.Slice:
 		if v.IsNil() {
 			return &Invalidor{
-				err: fmt.Errorf("mil element at simple path %s element was %s expected array,slice,map,struct", scope.Path(), "nil"),
+				err: fmt.Errorf("nil element at simple path %s element was %s expected array,slice,map,struct", scope.Path(), "nil"),
 			}
 		}
 		for i := 0; i < v.Len(); i++ {

--- a/reflector.go
+++ b/reflector.go
@@ -56,7 +56,7 @@ func (r *Reflector) subPath(path string, v reflect.Value, p string, pv *reflect.
 		if v.IsNil() {
 			p += path
 			result = &Invalidor{
-				err: fmt.Errorf("mil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
+				err: fmt.Errorf("nil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
 			}
 			break
 		}
@@ -65,7 +65,7 @@ func (r *Reflector) subPath(path string, v reflect.Value, p string, pv *reflect.
 		if v.IsNil() {
 			p += path
 			result = &Invalidor{
-				err: fmt.Errorf("mil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
+				err: fmt.Errorf("nil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
 			}
 			break
 		}
@@ -76,7 +76,7 @@ func (r *Reflector) subPath(path string, v reflect.Value, p string, pv *reflect.
 		if v.IsNil() {
 			p += path
 			result = &Invalidor{
-				err: fmt.Errorf("mil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
+				err: fmt.Errorf("nil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
 			}
 			break
 		}
@@ -85,7 +85,7 @@ func (r *Reflector) subPath(path string, v reflect.Value, p string, pv *reflect.
 		if v.IsNil() {
 			p += path
 			result = &Invalidor{
-				err: fmt.Errorf("mil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
+				err: fmt.Errorf("nil element at simple path %s element was %s expected array,slice,map,struct", p, "nil"),
 			}
 			break
 		}


### PR DESCRIPTION
## Summary
- correct "mil element" typo to "nil element" in collections.go and reflector.go

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e69c74984832f9c6e97903e94a725