### PR TITLE
Fix path string update during slice index lookup

### DIFF
--- a/reflectutil.go
+++ b/reflectutil.go
@@ -153,7 +153,6 @@ func arrayOrSlicePath(prefix string, path interface{}, v reflect.Value) Pathor {
 			}
 		}
 	default:
-		pathS = fmt.Sprintf("%d", i)
 		pathI, err := interfaceToInt(path)
 		if err != nil {
 			p := prefix + "[" + strconv.Quote(pathS) + "]"
@@ -163,6 +162,7 @@ func arrayOrSlicePath(prefix string, path interface{}, v reflect.Value) Pathor {
 			}
 		}
 		i = int64(pathI)
+		pathS = fmt.Sprintf("%d", i)
 	}
 	p := prefix + "[" + strconv.Quote(pathS) + "]"
 	l := int64(v.Len())


### PR DESCRIPTION
## Summary
- correctly update `pathS` after integer conversion in `arrayOrSlicePath`
- run `gofmt`

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: ineffassign, staticcheck, unused)*

------
https://chatgpt.com/codex/tasks/task_e_684e6b986e68832f97c18cb97df87175