### PR TITLE
Fix variable declarations in examples

### DIFF
--- a/examples/interfacor1/main.go
+++ b/examples/interfacor1/main.go
@@ -61,7 +61,7 @@ func main() {
 			},
 		},
 	}
-	var root lookup.Pathor = lookup.NewInterfaceor(&InterfaceorNode{
+	root := lookup.NewInterfaceor(&InterfaceorNode{
 		Node: rootNode,
 	})
 	log.Printf("A = %s", root.Raw())

--- a/examples/interfacor1/main_test.go
+++ b/examples/interfacor1/main_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 			},
 		},
 	}
-	var root lookup.Pathor = lookup.NewInterfaceor(&InterfaceorNode{
+	root := lookup.NewInterfaceor(&InterfaceorNode{
 		Node: rootNode,
 	})
 	assert.Equal(t, "A(B(D()),C())", fmt.Sprintf("%s", root.Raw()), "A failed")

--- a/reflectutil.go
+++ b/reflectutil.go
@@ -75,7 +75,7 @@ func arrayOrSliceForEachPath(prefix string, paths []string, v reflect.Value, run
 	}
 	switch len(typeCount) {
 	case 0:
-		var err error = ErrNoMatchesForQuery
+		err := ErrNoMatchesForQuery
 		if len(paths) == 0 && len(runners) > 0 {
 			err = ErrEvalFail
 		}


### PR DESCRIPTION
## Summary
- use short var declarations in example code
- inline error initialization in array/slice helper

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: ineffectual assignment and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_684e6bb10c24832f8308c30593aab84a