### PR TITLE
Fix regex string in collections.go

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -177,7 +177,7 @@ func evaluateType(scope *Scope, pathor Pathor, i interface{}) Pathor {
 		}
 		return arrayOrSlicePath(fmt.Sprintf("%s[%d]", ExtractPath(pathor), ip), ip, pathor.Value())
 	case reflect.String:
-		simpleValue, err := regexp.Compile("^-?\\d+$")
+		simpleValue, err := regexp.Compile(`^-?\d+$`)
 		if err != nil {
 			return NewInvalidor(ExtractPath(pathor), err)
 		}


### PR DESCRIPTION
## Summary
- use raw string literal for integer regex in `collections.go`
- ran `gofmt`, `go test`, and `golangci-lint`

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: ineffassign, staticcheck, unused)*

------
https://chatgpt.com/codex/tasks/task_e_684e6b5f0cfc832f9b8788b5a4dd1be7