### PR TITLE
Fix Constantor path var initialization

### DIFF
--- a/constantor.go
+++ b/constantor.go
@@ -64,7 +64,7 @@ func (r *Constantor) Value() reflect.Value {
 
 // Find returns a new Constinator with the same object but with an updated path if required.
 func (r *Constantor) Find(path string, opts ...Runner) Pathor {
-	p := r.path
+	var p string
 	if len(r.path) > 0 {
 		p = r.path + "." + path
 	} else {


### PR DESCRIPTION
## Summary
- fix local variable initialization in `Constantor.Find`
- run gofmt

## Testing
- `go test ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e6b51b270832f9ff187ed1fe86cab