### PR TITLE
Fix switch order in evaluateType

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -190,11 +190,11 @@ func evaluateType(scope *Scope, pathor Pathor, i interface{}) Pathor {
 		}
 	case reflect.Struct, reflect.Ptr:
 		switch ii := i.(type) {
+		case *Constantor:
+			return evaluateType(scope, pathor, ii.Raw())
 		case Runner:
 			p := ii.Run(scope)
 			return evaluateType(scope, p, p.Raw())
-		case *Constantor:
-			return evaluateType(scope, pathor, ii.Raw())
 		default:
 			return NewInvalidor(ExtractPath(pathor), ErrIndexValueNotValid)
 		}

--- a/collections_test.go
+++ b/collections_test.go
@@ -1,0 +1,22 @@
+package lookup
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"strings"
+	"testing"
+)
+
+func TestIndexConstantorPath(t *testing.T) {
+	type Root struct{ Arr []int }
+	root := &Root{Arr: []int{0, 1, 2}}
+
+	r := Reflect(root).Find("Arr").Find("", Index(NewConstantor("Const", 1)))
+	t.Logf("raw=%v path=%s", r.Raw(), ExtractPath(r))
+
+	if diff := cmp.Diff(1, r.Raw()); diff != "" {
+		t.Errorf("value mismatch: %s", diff)
+	}
+	if p := ExtractPath(r); !strings.HasPrefix(p, "Arr[1]") {
+		t.Errorf("path mismatch got %s", p)
+	}
+}


### PR DESCRIPTION
## Summary
- move `case *Constantor:` above `case Runner:` in `collections.go`
- add regression test for indexing with a constant
- gofmt

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: ineffassign, staticcheck, unused)*

------
https://chatgpt.com/codex/tasks/task_e_684e6b712810832fb98ad58590ccffda