### PR TITLE
Fix error type reporting in Interfaceor

### DIFF
--- a/interfaceor.go
+++ b/interfaceor.go
@@ -42,7 +42,7 @@ func (i *Interfaceor) Find(path string, opts ...Runner) Pathor {
 			ni = nii
 		default:
 			ni = &Invalidor{
-				err:  fmt.Errorf("invalid return type: %s", reflect.TypeOf(ni)),
+				err:  fmt.Errorf("invalid return type: %s", reflect.TypeOf(nii)),
 				path: p,
 			}
 		}


### PR DESCRIPTION
## Summary
- show offending type instead of `Pathor` when interface returned an unexpected type

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e6d18f53c832fa85b9f7ae8e16696