### PR TITLE
Support custom runners for Truthy and ToBool

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -221,10 +221,9 @@ func (ef *everyFunc) Run(scope *Scope) Pathor {
 
 func every(scope *Scope, everyThis Pathor) Pathor {
 	v := everyThis.Value()
-	result := scope.Current
 	every := true
 	if err := forEach(scope, v, func(pathor Pathor) error {
-		p := Truthy(NewConstantor(ExtractPath(result), result.Raw())).Run(scope.Next(pathor))
+		p := Truthy(Result()).Run(scope.Next(pathor))
 		b, err := interfaceToBoolOrParse(p.Raw())
 		if err == nil && b {
 			every = false

--- a/expression.go
+++ b/expression.go
@@ -34,13 +34,23 @@ func (ef *matchFunc) Run(scope *Scope) Pathor {
 }
 
 func ToBool(expression Runner) *toBoolFunc {
-	return &toBoolFunc{}
+	return &toBoolFunc{
+		expression: expression,
+	}
 }
 
-type toBoolFunc struct{}
+type toBoolFunc struct {
+	expression Runner
+}
 
 func (s *toBoolFunc) Run(scope *Scope) Pathor {
-	b, err := interfaceToBoolOrParse(scope.Position.Raw())
+	var result Pathor
+	if s.expression != nil {
+		result = s.expression.Run(scope)
+	} else {
+		result = scope.Position
+	}
+	b, err := interfaceToBoolOrParse(result.Raw())
 	if err != nil {
 		return NewInvalidor(scope.Path(), err)
 	}
@@ -48,13 +58,22 @@ func (s *toBoolFunc) Run(scope *Scope) Pathor {
 }
 
 func Truthy(expression Runner) *truthyFunc {
-	return &truthyFunc{}
+	return &truthyFunc{
+		expression: expression,
+	}
 }
 
-type truthyFunc struct{}
+type truthyFunc struct {
+	expression Runner
+}
 
 func (s *truthyFunc) Run(scope *Scope) Pathor {
-	result := scope.Position
+	var result Pathor
+	if s.expression != nil {
+		result = s.expression.Run(scope)
+	} else {
+		result = scope.Position
+	}
 	return truthy(scope, result)
 }
 

--- a/expression_test.go
+++ b/expression_test.go
@@ -1,0 +1,22 @@
+package lookup
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestToBool_WithRunner(t *testing.T) {
+	scope := NewScope(nil, NewConstantor("", false))
+	got := ToBool(Constant("true")).Run(scope)
+	if diff := cmp.Diff(true, got.Raw()); diff != "" {
+		t.Fatalf("unexpected result: %v", diff)
+	}
+}
+
+func TestTruthy_WithRunner(t *testing.T) {
+	scope := NewScope(nil, NewConstantor("", false))
+	got := Truthy(Constant(1)).Run(scope)
+	if diff := cmp.Diff(true, got.Raw()); diff != "" {
+		t.Fatalf("unexpected result: %v", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- store supplied `Runner` in `ToBool`/`Truthy`
- execute that `Runner` when converting to bool or truthy evaluation
- adjust `every` to use the new Truthy semantics
- add tests covering custom `Runner` usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e6d05b120832f98194a8405be604d