### PR TITLE
Add minimal JSONata parser and compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ Please contribute any external libraries that build upon `lookup` here:
 
 Bug reports and pull requests are welcome on GitHub. Feel free to open issues for discussion or ideas.
 
-A JSONata parser built on top of this library is planned. Once available it will be linked here.
+See [docs/jsonata.md](docs/jsonata.md) for a minimal JSONata parser built on top
+of this package.
 
 ## License
 

--- a/docs/jsonata.md
+++ b/docs/jsonata.md
@@ -1,0 +1,24 @@
+# JSONata Integration
+
+The `jsonata` package provides a tiny parser and compiler that translate a very
+small subset of JSONata syntax into `lookup` queries.
+
+Supported features:
+
+- Dot separated field navigation (`foo.bar`)
+- Array indexes (`arr[0]`, `arr[-1]`)
+- Equality filters (`books[author="Bob"]`)
+
+Parsing yields an AST which can be compiled into a `lookup.Relator`. The
+relator implements the `Runner` interface so it can be executed like other
+modifiers.
+
+```go
+ast, _ := jsonata.Parse("Children[Name='child1'].Size")
+query := jsonata.Compile(ast)
+
+root := lookup.Reflect(data)
+size := query.Run(lookup.NewScope(root, root)).Raw()
+```
+
+This example selects the `Size` of the child whose `Name` equals `child1`.

--- a/jsonata/ast.go
+++ b/jsonata/ast.go
@@ -1,0 +1,19 @@
+package jsonata
+
+// AST represents a parsed JSONata expression.
+type AST struct {
+	Steps []Step
+}
+
+// Step describes a navigation step in the query.
+type Step struct {
+	Name   string     // field name
+	Index  *int       // optional index
+	Filter *Predicate // optional equality filter
+}
+
+// Predicate represents a simple equality condition.
+type Predicate struct {
+	Field string
+	Value string
+}

--- a/jsonata/compile.go
+++ b/jsonata/compile.go
@@ -1,0 +1,23 @@
+package jsonata
+
+import (
+	"github.com/arran4/lookup"
+)
+
+// Compile converts the AST into a lookup.Relator which implements Runner.
+func Compile(ast *AST) *lookup.Relator {
+	r := lookup.NewRelator()
+	for _, step := range ast.Steps {
+		opts := []lookup.Runner{}
+		if step.Index != nil {
+			opts = append(opts, lookup.Index(*step.Index))
+		}
+		if step.Filter != nil {
+			opts = append(opts, lookup.Filter(
+				lookup.This(step.Filter.Field).Find("", lookup.Equals(lookup.Constant(step.Filter.Value))),
+			))
+		}
+		r = r.Find(step.Name, opts...)
+	}
+	return r
+}

--- a/jsonata/jsonata_test.go
+++ b/jsonata/jsonata_test.go
@@ -1,0 +1,53 @@
+package jsonata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arran4/lookup"
+	"github.com/stretchr/testify/assert"
+)
+
+type Node struct {
+	Name     string
+	Size     int
+	Tags     []string
+	Children []*Node
+}
+
+func runQuery(t *testing.T, data interface{}, q string) interface{} {
+	ast, err := Parse(q)
+	assert.NoError(t, err)
+	r := Compile(ast)
+	root := lookup.Reflect(data)
+	res := r.Run(lookup.NewScope(root, root))
+	return res.Raw()
+}
+
+func TestStructQueries(t *testing.T) {
+	root := &Node{
+		Name: "root",
+		Size: 3,
+		Children: []*Node{
+			{Name: "child1", Size: 1},
+			{Name: "child2", Size: 2},
+		},
+	}
+
+	assert.Equal(t, "root", runQuery(t, root, "Name"))
+	assert.Equal(t, "child2", runQuery(t, root, "Children[1].Name"))
+	assert.Equal(t, []int{2}, runQuery(t, root, "Children[Name='child2'].Size"))
+}
+
+func TestJSONQueries(t *testing.T) {
+	jsonData := []byte(`{"users":[{"name":"bob","age":5},{"name":"sam","age":7}]}`)
+	var v struct {
+		Users []struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		} `json:"users"`
+	}
+	json.Unmarshal(jsonData, &v)
+
+	assert.Equal(t, []int{7}, runQuery(t, v, "Users[Name='sam'].Age"))
+}

--- a/jsonata/parser.go
+++ b/jsonata/parser.go
@@ -1,0 +1,141 @@
+package jsonata
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Parse converts a JSONata expression into an AST.
+// It supports a very small subset of the language:
+//   - dot separated field names
+//   - array indexes like [0] or [-1]
+//   - equality filters like [field="value"]
+func Parse(expr string) (*AST, error) {
+	p := &parser{s: expr}
+	ast, err := p.parse()
+	if err != nil {
+		return nil, err
+	}
+	return ast, nil
+}
+
+type parser struct {
+	s string
+	i int
+}
+
+func (p *parser) parse() (*AST, error) {
+	ast := &AST{}
+	for {
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		step := Step{Name: name}
+		// zero or more brackets
+		for p.peek() == '[' {
+			p.i++ // consume '['
+			if p.peek() == ']' {
+				return nil, fmt.Errorf("empty brackets")
+			}
+			if isDigit(p.peek()) || p.peek() == '-' {
+				// index
+				numStr := p.readUntil(']')
+				p.i++ // consume closing
+				num, err := strconv.Atoi(numStr)
+				if err != nil {
+					return nil, fmt.Errorf("invalid index %s", numStr)
+				}
+				step.Index = &num
+			} else {
+				field, err := p.parseIdent()
+				if err != nil {
+					return nil, err
+				}
+				if p.peek() != '=' {
+					return nil, fmt.Errorf("expected '=' after %s", field)
+				}
+				p.i++
+				val, err := p.parseValue()
+				if err != nil {
+					return nil, err
+				}
+				if p.peek() != ']' {
+					return nil, fmt.Errorf("expected closing bracket")
+				}
+				p.i++
+				step.Filter = &Predicate{Field: field, Value: val}
+			}
+		}
+		ast.Steps = append(ast.Steps, step)
+		if p.i >= len(p.s) {
+			break
+		}
+		if p.s[p.i] != '.' {
+			return nil, fmt.Errorf("expected '.' at position %d", p.i)
+		}
+		p.i++
+	}
+	return ast, nil
+}
+
+func (p *parser) parseIdent() (string, error) {
+	start := p.i
+	for p.i < len(p.s) {
+		c := p.s[p.i]
+		if !(c == '_' || c == '$' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' ||
+			(p.i > start && (c >= '0' && c <= '9'))) {
+			break
+		}
+		p.i++
+	}
+	if start == p.i {
+		return "", fmt.Errorf("expected identifier at %d", start)
+	}
+	return p.s[start:p.i], nil
+}
+
+func (p *parser) parseValue() (string, error) {
+	if p.peek() == '\'' || p.peek() == '"' {
+		quote := p.s[p.i]
+		p.i++
+		start := p.i
+		for p.i < len(p.s) && p.s[p.i] != quote {
+			p.i++
+		}
+		if p.i >= len(p.s) {
+			return "", fmt.Errorf("unterminated string")
+		}
+		val := p.s[start:p.i]
+		p.i++ // consume closing quote
+		return val, nil
+	}
+	start := p.i
+	for p.i < len(p.s) && (isDigit(p.s[p.i]) || p.s[p.i] == '-') {
+		p.i++
+	}
+	if start == p.i {
+		return "", fmt.Errorf("expected value")
+	}
+	return p.s[start:p.i], nil
+}
+
+func (p *parser) peek() byte {
+	if p.i >= len(p.s) {
+		return 0
+	}
+	return p.s[p.i]
+}
+
+func (p *parser) readUntil(ch byte) string {
+	start := p.i
+	for p.i < len(p.s) && p.s[p.i] != ch {
+		p.i++
+	}
+	return strings.TrimSpace(p.s[start:p.i])
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}


### PR DESCRIPTION
## Summary
- implement a small JSONata parser and AST
- compile the AST to `lookup` runners
- document the new package
- provide end-to-end tests using structs and JSON data

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e6d300d9c832f91621bf77c986fb4