### PR TITLE
Clarify simple path parser naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ name = root
 size = 10
 ```
 
+### Query Strings
+
+For quick lookups the library understands a tiny query language that mirrors the
+`Find` API. Paths are written using dot notation with optional array/slice
+indexes in brackets. Negative indexes count from the end of the collection.
+The helper `lookup.QuerySimplePath` parses the expression and runs it against your value:
+
+```go
+// Get the value of root.A.B[0].C
+result := lookup.QuerySimplePath(root, "A.B[0].C").Raw()
+
+// Last element using a negative index
+last := lookup.QuerySimplePath(root, "A.B[-1].C").Raw()
+```
+
+If you need to reuse a query repeatedly you can compile it once using
+`lookup.ParseSimplePath` which returns a `Relator` that can be executed on any `Pathor`.
+
 ## Modifiers
 
 Modifiers are `Runner` implementations that transform the current scope of a lookup. They are passed to `Find` after the path name.

--- a/simplepath_parser.go
+++ b/simplepath_parser.go
@@ -1,0 +1,51 @@
+package lookup
+
+import "strings"
+
+// ParseSimplePath converts a simple query string like "A.B[0].C" into a Relator
+// which can be run against any Pathor. The supported syntax only understands
+// dot separated field lookups and integer based indexes using square brackets.
+func ParseSimplePath(query string) *Relator {
+	r := NewRelator()
+	token := strings.Builder{}
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '.':
+			if token.Len() > 0 {
+				r = r.Find(token.String())
+				token.Reset()
+			}
+			i++
+		case '[':
+			if token.Len() > 0 {
+				r = r.Find(token.String())
+				token.Reset()
+			}
+			j := strings.IndexByte(query[i:], ']')
+			if j == -1 {
+				// no closing bracket, treat rest as plain text
+				token.WriteString(query[i:])
+				i = len(query)
+				break
+			}
+			idx := query[i+1 : i+j]
+			r = r.Find("", Index(idx))
+			i += j + 1
+		default:
+			token.WriteByte(query[i])
+			i++
+		}
+	}
+	if token.Len() > 0 {
+		r = r.Find(token.String())
+	}
+	return r
+}
+
+// QuerySimplePath executes the given simple path query string against the
+// provided value using reflection.
+func QuerySimplePath(v interface{}, query string) Pathor {
+	rel := ParseSimplePath(query)
+	root := Reflect(v)
+	return rel.Run(NewScope(nil, root))
+}

--- a/simplepath_parser_test.go
+++ b/simplepath_parser_test.go
@@ -1,0 +1,53 @@
+package lookup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testNode struct {
+	A struct {
+		B []struct {
+			C int
+		}
+	}
+}
+
+func newTestNode() *testNode {
+	n := &testNode{}
+	n.A.B = []struct{ C int }{{C: 1}, {C: 2}}
+	return n
+}
+
+func TestParseSimplePath(t *testing.T) {
+	root := newTestNode()
+	r := ParseSimplePath("A.B[0].C")
+	res := r.Run(NewScope(nil, Reflect(root)))
+	assert.Equal(t, 1, res.Raw())
+}
+
+func TestQuerySimplePath(t *testing.T) {
+	root := newTestNode()
+	res := QuerySimplePath(root, "A.B[-1].C")
+	assert.Equal(t, 2, res.Raw())
+}
+
+func TestQueryInvalid(t *testing.T) {
+	root := newTestNode()
+	res := QuerySimplePath(root, "A.B[10].C")
+	assert.IsType(t, &Invalidor{}, res)
+}
+
+func TestQueryNested(t *testing.T) {
+	type nested struct{ A [][]int }
+	n := &nested{A: [][]int{{1, 2}, {3, 4}}}
+	res := QuerySimplePath(n, "A[1][0]")
+	assert.Equal(t, 3, res.Raw())
+}
+
+func TestParseUnmatchedBracket(t *testing.T) {
+	root := newTestNode()
+	res := QuerySimplePath(root, "A.B[0.C")
+	assert.IsType(t, &Invalidor{}, res)
+}


### PR DESCRIPTION
## Summary
- rename `Parse` to `ParseSimplePath` and `Query` to `QuerySimplePath`
- update documentation and tests to use the new names
- move parser implementation to `simplepath_parser.go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e6d21ecdc832f9433d7afee1874f9