### PR TITLE
Add benchmarks to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,18 @@ jobs:
       - name: Test
         run: go test ./...
       - name: Benchmarks
-        run: go test -run=^$ -bench . ./...
+        id: bench
+        run: |
+          go test -run=^$ -bench . ./... -benchmem | tee bench.txt
+      - name: Comment Benchmarks
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const bench = fs.readFileSync('bench.txt', 'utf8');
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `Benchmark results (${process.env['RUNNER_OS']}):\n\n\`\`\`\n${bench}\n\`\`\``
+            });


### PR DESCRIPTION
## Summary
- remove CONTRIBUTING.md
- post benchmark output as a pull request comment in the test workflow

## Benchmark Results
```
BenchmarkFindNestedStruct-5      1969801               591.2 ns/op
BenchmarkFindNestedMap-5          982748              1188 ns/op
BenchmarkFindIndex-5             1714188               745.3 ns/op
BenchmarkFilterChildren-5         169288              6853 ns/op
BenchmarkMapIndex-5               145716              7903 ns/op
BenchmarkAnyContains-5            197761              5498 ns/op
BenchmarkInterfaceorNested-5     5654292               213.1 ns/op
```


------
https://chatgpt.com/codex/tasks/task_e_684e75eb506c832f8f43b55d07d03954