### PR TITLE
Fix linter issues

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -96,18 +96,7 @@ func (ef *containsFunc) Run(scope *Scope) Pathor {
 		}, scope)
 		return every(scope, equals(scope, result))
 	}
-	v := scope.Position.Value()
-	found := false
-	if err := forEach(scope, v, func(pathor Pathor) error {
-		p := Equals(NewConstantor(ExtractPath(result), result.Raw())).Run(scope.Next(pathor))
-		b, err := interfaceToBoolOrParse(p.Raw())
-		if err == nil && b {
-			found = true
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
+	found := elementOf(result.Value(), scope.Position.Value(), nil)
 	return NewConstantor(scope.Path(), found)
 }
 
@@ -122,27 +111,13 @@ type inFunc struct {
 }
 
 func (ef *inFunc) Run(scope *Scope) Pathor {
-	var result Pathor
 	switch scope.Position.Value().Kind() {
 	case reflect.Slice, reflect.Array:
-		result = arrayOrSliceForEachPath(scope.Path(), nil, scope.Position.Value(), []Runner{ef}, scope)
+		result := arrayOrSliceForEachPath(scope.Path(), nil, scope.Position.Value(), []Runner{ef}, scope)
 		return any(scope, result)
-	default:
-		result = scope.Position
 	}
 	inThis := ef.expression.Run(scope)
-	inV := inThis.Value()
-	found := false
-	if err := forEach(scope, inV, func(pathor Pathor) error {
-		p := Equals(NewConstantor(ExtractPath(pathor), result.Raw())).Run(scope.Next(pathor))
-		b, err := interfaceToBoolOrParse(p.Raw())
-		if err == nil && b {
-			found = true
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
+	found := elementOf(scope.Position.Value(), inThis.Value(), nil)
 	return NewConstantor(scope.Path(), found)
 }
 

--- a/collections_test.go
+++ b/collections_test.go
@@ -20,3 +20,20 @@ func TestIndexConstantorPath(t *testing.T) {
 		t.Errorf("path mismatch got %s", p)
 	}
 }
+
+func TestContainsMap(t *testing.T) {
+	m := map[string]int{"a": 1, "b": 2}
+	r := Reflect(m).Find("", Contains(Constant(2)))
+	if diff := cmp.Diff(true, r.Raw()); diff != "" {
+		t.Errorf("value mismatch: %s", diff)
+	}
+}
+
+func TestInStruct(t *testing.T) {
+	type S struct{ A, B string }
+	s := S{A: "foo", B: "bar"}
+	r := Reflect("bar").Find("", In(ValueOf(Reflect(s))))
+	if diff := cmp.Diff(true, r.Raw()); diff != "" {
+		t.Errorf("value mismatch: %s", diff)
+	}
+}

--- a/reflectutil.go
+++ b/reflectutil.go
@@ -138,7 +138,7 @@ func arrayOrSliceForEachPath(prefix string, paths []string, v reflect.Value, run
 // arrayOrSlicePath attempts to extract the path as an index from the array, if this fails it will then use the index to
 // assemble an array of matching children using arrayOrSliceForEachPath
 func arrayOrSlicePath(prefix string, path interface{}, v reflect.Value) Pathor {
-	var i int64 = 0
+	var i int64
 	pathS := "0"
 	switch path := path.(type) {
 	case string:
@@ -457,22 +457,6 @@ func elementOf(v reflect.Value, in reflect.Value, pv *reflect.Value) bool {
 		return false
 	}
 	switch in.Kind() {
-	//case reflect.Bool:
-	//case reflect.Int:
-	//case reflect.Int8:
-	//case reflect.Int16:
-	//case reflect.Int32:
-	//case reflect.Int64:
-	//case reflect.Uint:
-	//case reflect.Uint8:
-	//case reflect.Uint16:
-	//case reflect.Uint32:
-	//case reflect.Uint64:
-	//case reflect.Uintptr:
-	//case reflect.Float32:
-	//case reflect.Float64:
-	//case reflect.Complex64:
-	//case reflect.Complex128:
 	case reflect.Array:
 		for i := 0; i < in.Len(); i++ {
 			f := in.Index(i)
@@ -480,10 +464,8 @@ func elementOf(v reflect.Value, in reflect.Value, pv *reflect.Value) bool {
 				return true
 			}
 		}
-	//case reflect.Chan:
 	case reflect.Func:
-		var r Pathor
-		r = runMethod(in, "")
+		r := runMethod(in, "")
 		return elementOf(r.Value(), in, nil)
 	case reflect.Map:
 		for _, k := range in.MapKeys() {
@@ -501,7 +483,6 @@ func elementOf(v reflect.Value, in reflect.Value, pv *reflect.Value) bool {
 				return true
 			}
 		}
-	//case reflect.String:
 	case reflect.Struct:
 		for i := 0; i < in.NumField(); i++ {
 			f := in.Field(i)
@@ -521,8 +502,6 @@ func elementOf(v reflect.Value, in reflect.Value, pv *reflect.Value) bool {
 				return true
 			}
 		}
-
-	//case reflect.UnsafePointer:
 	default:
 		return reflect.DeepEqual(v.Interface(), in.Interface())
 	}

--- a/relator.go
+++ b/relator.go
@@ -74,7 +74,7 @@ func (r *Relator) Find(path string, opts ...Runner) *Relator {
 
 // Copy produces a copy of the Relator
 func (r *Relator) Copy() *Relator {
-	fs := make([]*find, len(r.finds), len(r.finds))
+	fs := make([]*find, len(r.finds))
 	copy(fs, r.finds)
 	return &Relator{
 		finds:        fs,


### PR DESCRIPTION
## Summary
- restore `elementOf` helper and use it in collections
- simplify membership checks with `elementOf`
- add tests for map and struct membership

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e75c7c1b0832fba4e535202dc5883