### PR TITLE
Fix relator copy slice allocation

### DIFF
--- a/relator.go
+++ b/relator.go
@@ -74,7 +74,7 @@ func (r *Relator) Find(path string, opts ...Runner) *Relator {
 
 // Copy produces a copy of the Relator
 func (r *Relator) Copy() *Relator {
-	fs := make([]*find, len(r.finds), len(r.finds))
+	fs := make([]*find, len(r.finds))
 	copy(fs, r.finds)
 	return &Relator{
 		finds:        fs,

--- a/relator_test.go
+++ b/relator_test.go
@@ -52,6 +52,29 @@ func TestRelator_Evaluate(t *testing.T) {
 	}
 }
 
+func TestRelator_CopyCreatesSeparateSlice(t *testing.T) {
+	r := NewRelator().Find("F1")
+	c := r.Copy()
+
+	if len(r.finds) != len(c.finds) {
+		t.Fatalf("copy length mismatch got %d want %d", len(c.finds), len(r.finds))
+	}
+
+	if len(r.finds) > 0 && &r.finds[0] == &c.finds[0] {
+		t.Errorf("copy shares slice backing array with original")
+	}
+
+	r.Find("F2")
+
+	if len(r.finds) != 2 {
+		t.Errorf("original relator expected 2 finds got %d", len(r.finds))
+	}
+
+	if len(c.finds) != 1 {
+		t.Errorf("copy relator expected 1 find got %d", len(c.finds))
+	}
+}
+
 func TestRelator_FromHere(t *testing.T) {
 	type BoolField struct {
 		Value1 bool


### PR DESCRIPTION
## Summary
- fix slice allocation when copying in Relator
- add test ensuring copies use independent slices
- run gofmt

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: ineffassign, staticcheck, unused)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ba266a4832fb9746598aa3e01e1