### PR TITLE
Refactor CLI apps for direct testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.24.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,62 @@
+version: 2
+project_name: lookup
+builds:
+  - id: json-simpe-path
+    main: ./cmd/json-simpe-path
+    binary: json-simpe-path
+    env:
+      - CGO_ENABLED=0
+  - id: yaml-simpe-path
+    main: ./cmd/yaml-simpe-path
+    binary: yaml-simpe-path
+    env:
+      - CGO_ENABLED=0
+archives:
+  - id: json
+    builds: [json-simpe-path]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_json_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+  - id: yaml
+    builds: [yaml-simpe-path]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_yaml_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: checksums.txt
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+man_pages:
+  - source: man/json-simpe-path.1
+    target: json-simpe-path.1
+    builds: [json-simpe-path]
+  - source: man/yaml-simpe-path.1
+    target: yaml-simpe-path.1
+    builds: [yaml-simpe-path]
+nfpms:
+  - vendor: Ubels Software Development
+    homepage: https://github.com/arran4/
+    maintainer: Arran Ubels <arran@ubels.com.au>
+    description: NA
+    license: Private
+    formats:
+      - apk
+      - deb
+      - rpm
+      - termux.deb
+      - archlinux
+    release: 1
+    section: default
+    priority: extra
+release:
+  github:
+    owner: arran4
+    name: lookup

--- a/README.md
+++ b/README.md
@@ -233,6 +233,69 @@ During the query `Index(Constant("-1"))` sees:
 
 With other modifiers `Scope.Current` may differ from `Scope.Position`.
 
+## Command Line Tools
+
+Two helper binaries make navigating YAML and JSON from the shell easy. Both use
+lookup's `SimplePath` syntax and share the same set of options.
+
+### yaml-simpe-path
+
+Reads one or more YAML documents and prints selected values. The interface is
+inspired by classic Unix text processing tools with jq-style niceties.
+
+```
+Usage: yaml-simpe-path [options] PATH [PATH ...]
+
+Options:
+  -f string   YAML file to read (default stdin)
+  -e string   simple path query (can be repeated)
+  -d string   output delimiter (default "\n")
+  -json       output as JSON
+  -yaml       output as YAML (default)
+  -raw        output raw value without formatting
+  -grep str   only print results matching the regex
+  -v          invert regex match
+  -n          prefix results with their index
+  -0          use NUL as output delimiter
+  -count      only print the number of matched results
+```
+
+Example:
+
+```bash
+$ cat <<'EOF' > doc.yaml
+name: foo
+spec:
+  replicas: 3
+metadata:
+  name: prod-service
+EOF
+$ yaml-simpe-path -f doc.yaml .spec.replicas
+3
+```
+
+### json-simpe-path
+
+Operates on JSON input with the same flags. It defaults to JSON output but can
+emit YAML when `-yaml` is specified.
+
+```bash
+$ cat <<'EOF' > doc.json
+{"name":"foo","spec":{"replicas":3},"metadata":{"name":"prod-service"}}
+EOF
+$ json-simpe-path -f doc.json .spec.replicas
+3
+```
+
+Manual pages generated with `go-md2man` are available in the `man/` directory.
+
+## Releases
+
+Versioned releases are published automatically when a Git tag starting with
+`v` is pushed. The release workflow runs [GoReleaser](https://goreleaser.com)
+to build binaries for all supported platforms, package the man pages and upload
+the archives to GitHub.
+
 ## Extensions
 
 Please contribute any external libraries that build upon `lookup` here:

--- a/cmd/json-simpe-path/README.md
+++ b/cmd/json-simpe-path/README.md
@@ -1,0 +1,47 @@
+# json-simpe-path
+
+json-simpe-path is a small command line tool built on top of the lookup library. It reads one or more JSON documents and extracts values using lookup's `SimplePath` syntax. The interface should feel familiar to Unix users with options inspired by `cut`, `sed`, `grep` and modern tools such as `jq`.
+
+```
+Usage: json-simpe-path [options] PATH [PATH ...]
+
+Options:
+  -f string   JSON file to read (default stdin)
+  -e string   simple path query (can be repeated)
+  -d string   output delimiter (default "\n")
+  -json       output as JSON
+  -yaml       output as YAML
+  -raw        output raw value without formatting
+  -grep str   only print results matching the regex
+  -v          invert regex match
+  -n          prefix results with their index
+  -0          use NUL as output delimiter
+  -count      only print the number of matched results
+```
+
+The tool expects one or more lookup paths. If `-e` is supplied the flag value is treated as the first query followed by any additional paths on the command line. Each JSON document in the input stream is decoded in turn and every query is executed against it.
+
+Examples:
+
+```bash
+# Extract a field from a file
+$ cat <<'EOF' > doc.json
+{"name":"foo","spec":{"replicas":3},"metadata":{"name":"prod-service"}}
+EOF
+$ json-simpe-path -f doc.json .spec.replicas
+3
+
+# Output raw scalar values
+$ json-simpe-path -raw .spec.replicas < doc.json
+3
+
+# Only show values matching a pattern
+$ json-simpe-path -grep '^prod' -raw -f doc.json .metadata.name
+prod-service
+
+# Count how many documents have a metadata.name field
+$ json-simpe-path -count -f doc.json .metadata.name
+1
+```
+
+Multiple documents are separated by the chosen delimiter. By default results are printed as JSON but `-json` or `-raw` can be used for alternative output formats.

--- a/cmd/json-simpe-path/json-simpe-path.md
+++ b/cmd/json-simpe-path/json-simpe-path.md
@@ -1,0 +1,43 @@
+% JSON-SIMPE-PATH(1) go2man
+% Auto-generated
+% Jun 2025
+
+# NAME
+
+json-simpe-path - query JSON files using lookup paths
+
+# SYNOPSIS
+
+`json-simpe-path [options] PATH [PATH ...]`
+
+# DESCRIPTION
+
+Reads one or more JSON documents and extracts values with lookup's SimplePath syntax. It mirrors yaml-simpe-path but defaults to JSON input and output.
+
+# OPTIONS
+
+See README for details.
+
+# EXAMPLES
+
+```
+$ cat <<'J' > doc.json
+{"name":"foo","spec":{"replicas":3},"metadata":{"name":"prod-service"}}
+J
+$ json-simpe-path -f doc.json .spec.replicas
+3
+```
+
+```
+$ json-simpe-path -grep '^prod' .metadata.name doc.json
+prod-service
+```
+
+```
+$ json-simpe-path -count .metadata.name doc.json
+1
+```
+
+# SEE ALSO
+
+yaml-simpe-path(1)

--- a/cmd/json-simpe-path/main.go
+++ b/cmd/json-simpe-path/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/arran4/lookup"
+	"gopkg.in/yaml.v3"
+)
+
+func usage(fs *flag.FlagSet) {
+	fmt.Fprintf(fs.Output(), `Usage: %s [options] PATH [PATH ...]
+Options:
+  -f string  JSON file to read (default stdin)
+  -e string  simple path query (can be repeated)
+  -d string  output delimiter (default "\n")
+  -json      output as JSON (default)
+  -yaml      output as YAML
+  -raw       output raw values without formatting
+  -grep str  only print results matching the regex
+  -v         invert grep match
+  -n         prefix results with their index
+  -0         use NUL as output delimiter
+  -count     only print the number of matched results
+`, fs.Name())
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("json-simpe-path", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	file := fs.String("f", "", "input file")
+	queryFlag := fs.String("e", "", "simple path query")
+	delim := fs.String("d", "\n", "output delimiter")
+	jsonOut := fs.Bool("json", false, "output JSON")
+	yamlOut := fs.Bool("yaml", false, "output YAML")
+	rawOut := fs.Bool("raw", false, "output raw values")
+	grepExpr := fs.String("grep", "", "filter by regex")
+	invert := fs.Bool("v", false, "invert regex match")
+	number := fs.Bool("n", false, "number results")
+	nullDelim := fs.Bool("0", false, "use NUL as delimiter")
+	countOnly := fs.Bool("count", false, "only print match count")
+	fs.Usage = func() { usage(fs) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	queries := []string{}
+	if *queryFlag != "" {
+		queries = append(queries, *queryFlag)
+	}
+	queries = append(queries, fs.Args()...)
+	if len(queries) == 0 {
+		fs.Usage()
+		return fmt.Errorf("no query provided")
+	}
+
+	if *nullDelim {
+		*delim = "\x00"
+	}
+
+	var r io.Reader = stdin
+	if *file != "" {
+		f, err := os.Open(*file)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", *file, err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	dec := json.NewDecoder(r)
+
+	var re *regexp.Regexp
+	var err error
+	if *grepExpr != "" {
+		re, err = regexp.Compile(*grepExpr)
+		if err != nil {
+			return fmt.Errorf("invalid regex: %w", err)
+		}
+	}
+
+	index := 0
+	count := 0
+	first := true
+	for {
+		var doc interface{}
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("decode: %w", err)
+		}
+		for _, q := range queries {
+			res := lookup.QuerySimplePath(doc, q)
+			if res == nil {
+				continue
+			}
+			val := res.Raw()
+			if re != nil {
+				matched := re.MatchString(fmt.Sprint(val))
+				if *invert {
+					matched = !matched
+				}
+				if !matched {
+					continue
+				}
+			}
+			count++
+			if *countOnly {
+				continue
+			}
+			if !first {
+				fmt.Fprint(stdout, *delim)
+			}
+			first = false
+			if *number {
+				fmt.Fprintf(stdout, "%d:", index)
+			}
+			switch {
+			case *rawOut:
+				fmt.Fprint(stdout, fmt.Sprint(val))
+			case *yamlOut:
+				b, err := yaml.Marshal(val)
+				if err != nil {
+					return fmt.Errorf("yaml encode: %w", err)
+				}
+				fmt.Fprint(stdout, strings.TrimSuffix(string(b), "\n"))
+			case *jsonOut || (!*yamlOut && !*rawOut):
+				b, err := json.Marshal(val)
+				if err != nil {
+					return fmt.Errorf("json encode: %w", err)
+				}
+				fmt.Fprint(stdout, string(b))
+			}
+			index++
+		}
+	}
+	if *countOnly {
+		fmt.Fprint(stdout, count)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/json-simpe-path/main_test.go
+++ b/cmd/json-simpe-path/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const exampleJSON = `{"name":"foo","spec":{"replicas":3},"metadata":{"name":"prod-service"}}`
+
+func TestExamples(t *testing.T) {
+	tmp := t.TempDir()
+	fname := filepath.Join(tmp, "doc.json")
+	if err := os.WriteFile(fname, []byte(exampleJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		args  []string
+		stdin string
+		want  string
+	}{
+		{"field", []string{"-f", fname, ".spec.replicas"}, "", "3"},
+		{"raw", []string{"-raw", ".spec.replicas"}, exampleJSON, "3"},
+		{"grep", []string{"-f", fname, "-grep", "^prod", "-raw", ".metadata.name"}, "", "prod-service"},
+		{"count", []string{"-f", fname, "-count", ".metadata.name"}, "", "1"},
+	}
+
+	for _, c := range cases {
+		var in io.Reader = bytes.NewBufferString(c.stdin)
+		var out bytes.Buffer
+		err := run(c.args, in, &out, io.Discard)
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != c.want {
+			t.Errorf("%s: want %q got %q", c.name, c.want, got)
+		}
+	}
+}

--- a/cmd/yaml-simpe-path/README.md
+++ b/cmd/yaml-simpe-path/README.md
@@ -1,0 +1,51 @@
+# yaml-simpe-path
+
+yaml-simpe-path is a small command line tool built on top of the lookup library. It reads one or more YAML documents and extracts values using lookup's `SimplePath` syntax. The interface should feel familiar to Unix users with options inspired by `cut`, `sed`, `grep` and modern tools such as `jq`.
+
+```
+Usage: yaml-simpe-path [options] PATH [PATH ...]
+
+Options:
+  -f string   YAML file to read (default stdin)
+  -e string   simple path query (can be repeated)
+  -d string   output delimiter (default "\n")
+  -json       output as JSON
+  -yaml       output as YAML (default)
+  -raw        output raw value without formatting
+  -grep str   only print results matching the regex
+  -v          invert regex match
+  -n          prefix results with their index
+  -0          use NUL as output delimiter
+  -count      only print the number of matched results
+```
+
+The tool expects one or more lookup paths. If `-e` is supplied the flag value is treated as the first query followed by any additional paths on the command line. Each YAML document in the input stream is decoded in turn and every query is executed against it.
+
+Examples:
+
+```bash
+# Extract a field from a file
+$ cat <<'EOF' > doc.yaml
+name: foo
+spec:
+  replicas: 3
+metadata:
+  name: prod-service
+EOF
+$ yaml-simpe-path -f doc.yaml .spec.replicas
+3
+
+# Output raw scalar values
+$ yaml-simpe-path -raw .spec.replicas < doc.yaml
+3
+
+# Only show values matching a pattern
+$ yaml-simpe-path -grep '^prod' -f doc.yaml .metadata.name
+prod-service
+
+# Count how many documents have a metadata.name field
+$ yaml-simpe-path -count -f doc.yaml .metadata.name
+1
+```
+
+Multiple documents are separated by the chosen delimiter. By default results are printed as YAML but `-json` or `-raw` can be used for alternative output formats.

--- a/cmd/yaml-simpe-path/main.go
+++ b/cmd/yaml-simpe-path/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/arran4/lookup"
+	"gopkg.in/yaml.v3"
+)
+
+func usage(fs *flag.FlagSet) {
+	fmt.Fprintf(fs.Output(), `Usage: %s [options] PATH [PATH ...]
+Options:
+  -f string  YAML file to read (default stdin)
+  -e string  simple path query (can be repeated)
+  -d string  output delimiter (default "\n")
+  -json      output as JSON
+  -yaml      output as YAML
+  -raw       output raw values without formatting
+  -grep str  only print results matching the regex
+  -v         invert grep match
+  -n         prefix results with their index
+  -0         use NUL as output delimiter
+  -count     only print the number of matched results
+`, fs.Name())
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("yaml-simpe-path", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	file := fs.String("f", "", "input file")
+	queryFlag := fs.String("e", "", "simple path query")
+	delim := fs.String("d", "\n", "output delimiter")
+	jsonOut := fs.Bool("json", false, "output JSON")
+	yamlOut := fs.Bool("yaml", false, "output YAML")
+	rawOut := fs.Bool("raw", false, "output raw values")
+	grepExpr := fs.String("grep", "", "filter by regex")
+	invert := fs.Bool("v", false, "invert regex match")
+	number := fs.Bool("n", false, "number results")
+	nullDelim := fs.Bool("0", false, "use NUL as delimiter")
+	countOnly := fs.Bool("count", false, "only print match count")
+	fs.Usage = func() { usage(fs) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	queries := []string{}
+	if *queryFlag != "" {
+		queries = append(queries, *queryFlag)
+	}
+	queries = append(queries, fs.Args()...)
+	if len(queries) == 0 {
+		fs.Usage()
+		return fmt.Errorf("no query provided")
+	}
+
+	if *nullDelim {
+		*delim = "\x00"
+	}
+
+	var r io.Reader = stdin
+	if *file != "" {
+		f, err := os.Open(*file)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", *file, err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	dec := yaml.NewDecoder(r)
+
+	var re *regexp.Regexp
+	var err error
+	if *grepExpr != "" {
+		re, err = regexp.Compile(*grepExpr)
+		if err != nil {
+			return fmt.Errorf("invalid regex: %w", err)
+		}
+	}
+
+	index := 0
+	count := 0
+	first := true
+	for {
+		var doc interface{}
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("decode: %w", err)
+		}
+		for _, q := range queries {
+			res := lookup.QuerySimplePath(doc, q)
+			if res == nil {
+				continue
+			}
+			val := res.Raw()
+			if re != nil {
+				matched := re.MatchString(fmt.Sprint(val))
+				if *invert {
+					matched = !matched
+				}
+				if !matched {
+					continue
+				}
+			}
+			count++
+			if *countOnly {
+				continue
+			}
+			if !first {
+				fmt.Fprint(stdout, *delim)
+			}
+			first = false
+			if *number {
+				fmt.Fprintf(stdout, "%d:", index)
+			}
+			switch {
+			case *rawOut:
+				fmt.Fprint(stdout, fmt.Sprint(val))
+			case *jsonOut:
+				b, err := json.Marshal(val)
+				if err != nil {
+					return fmt.Errorf("json encode: %w", err)
+				}
+				fmt.Fprint(stdout, string(b))
+			case *yamlOut || (!*jsonOut && !*rawOut):
+				b, err := yaml.Marshal(val)
+				if err != nil {
+					return fmt.Errorf("yaml encode: %w", err)
+				}
+				fmt.Fprint(stdout, strings.TrimSuffix(string(b), "\n"))
+			}
+			index++
+		}
+	}
+	if *countOnly {
+		fmt.Fprint(stdout, count)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/yaml-simpe-path/main_test.go
+++ b/cmd/yaml-simpe-path/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const exampleYAML = `name: foo
+spec:
+  replicas: 3
+metadata:
+  name: prod-service
+`
+
+func TestExamples(t *testing.T) {
+	tmp := t.TempDir()
+	fname := filepath.Join(tmp, "doc.yaml")
+	if err := os.WriteFile(fname, []byte(exampleYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		args  []string
+		stdin string
+		want  string
+	}{
+		{"field", []string{"-f", fname, ".spec.replicas"}, "", "3"},
+		{"raw", []string{"-raw", ".spec.replicas"}, exampleYAML, "3"},
+		{"grep", []string{"-f", fname, "-grep", "^prod", ".metadata.name"}, "", "prod-service"},
+		{"count", []string{"-f", fname, "-count", ".metadata.name"}, "", "1"},
+	}
+
+	for _, c := range cases {
+		var in io.Reader = bytes.NewBufferString(c.stdin)
+		var out bytes.Buffer
+		err := run(c.args, in, &out, io.Discard)
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != c.want {
+			t.Errorf("%s: want %q got %q", c.name, c.want, got)
+		}
+	}
+}

--- a/cmd/yaml-simpe-path/yaml-simpe-path.md
+++ b/cmd/yaml-simpe-path/yaml-simpe-path.md
@@ -1,0 +1,47 @@
+% YAML-SIMPE-PATH(1) go2man
+% Auto-generated
+% Jun 2025
+
+# NAME
+
+yaml-simpe-path - query YAML files using lookup paths
+
+# SYNOPSIS
+
+`yaml-simpe-path [options] PATH [PATH ...]`
+
+# DESCRIPTION
+
+Reads one or more YAML documents and extracts values with lookup's SimplePath syntax. It mimics unix tools like cut, sed and grep while adding jq-like features.
+
+# OPTIONS
+
+See README for details.
+
+# EXAMPLES
+
+```
+$ cat <<'Y' > doc.yaml
+name: foo
+spec:
+  replicas: 3
+metadata:
+  name: prod-service
+Y
+$ yaml-simpe-path -f doc.yaml .spec.replicas
+3
+```
+
+```
+$ yaml-simpe-path -grep '^prod' .metadata.name doc.yaml
+prod-service
+```
+
+```
+$ yaml-simpe-path -count .metadata.name doc.yaml
+1
+```
+
+# SEE ALSO
+
+json-simpe-path(1)

--- a/man/json-simpe-path.1
+++ b/man/json-simpe-path.1
@@ -1,0 +1,43 @@
+.nh
+.TH JSON-SIMPE-PATH(1) go2man
+Auto-generated
+Jun 2025
+
+.SH NAME
+json-simpe-path \- query JSON files using lookup paths
+
+
+.SH SYNOPSIS
+\fBjson-simpe-path [options] PATH [PATH ...]\fR
+
+
+.SH DESCRIPTION
+Reads one or more JSON documents and extracts values with lookup's SimplePath syntax. It mirrors yaml-simpe-path but defaults to JSON input and output.
+
+
+.SH OPTIONS
+See README for details.
+
+
+.SH EXAMPLES
+.EX
+$ cat <<'EOF' > doc.json
+{"name":"foo","spec":{"replicas":3},"metadata":{"name":"prod-service"}}
+EOF
+$ json-simpe-path -f doc.json .spec.replicas
+3
+.EE
+
+.EX
+$ json-simpe-path -grep '^prod' -raw -f doc.json .metadata.name
+prod-service
+.EE
+
+.EX
+$ json-simpe-path -count -f doc.json .metadata.name
+1
+.EE
+
+
+.SH SEE ALSO
+yaml-simpe-path(1)

--- a/man/yaml-simpe-path.1
+++ b/man/yaml-simpe-path.1
@@ -1,0 +1,47 @@
+.nh
+.TH YAML-SIMPE-PATH(1) go2man
+Auto-generated
+Jun 2025
+
+.SH NAME
+yaml-simpe-path \- query YAML files using lookup paths
+
+
+.SH SYNOPSIS
+\fByaml-simpe-path [options] PATH [PATH ...]\fR
+
+
+.SH DESCRIPTION
+Reads one or more YAML documents and extracts values with lookup's SimplePath syntax. It mimics unix tools like cut, sed and grep while adding jq-like features.
+
+
+.SH OPTIONS
+See README for details.
+
+
+.SH EXAMPLES
+.EX
+$ cat <<'EOF' > doc.yaml
+name: foo
+spec:
+  replicas: 3
+metadata:
+  name: prod-service
+EOF
+$ yaml-simpe-path -f doc.yaml .spec.replicas
+3
+.EE
+
+.EX
+$ yaml-simpe-path -grep '^prod' -f doc.yaml .metadata.name
+prod-service
+.EE
+
+.EX
+$ yaml-simpe-path -count -f doc.yaml .metadata.name
+1
+.EE
+
+
+.SH SEE ALSO
+json-simpe-path(1)


### PR DESCRIPTION
## Summary
- expose a `run` function for `yaml-simpe-path` and `json-simpe-path`
- update tests to call the new function instead of exec'ing `go run`
- keep examples using full command names

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e76d90e88832fad7aff6922a09be7