### PR TITLE
Limit benchmark comments to one OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Test
         run: go test ./...
       - name: Benchmarks
+        if: matrix.os == 'ubuntu-latest'
         id: bench
         run: |
           go test -run=^$ -bench . ./... -benchmem | tee bench.txt
       - name: Comment Benchmarks
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- run benchmarks only on ubuntu runner
- only comment benchmark results from that run

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ec20dcb00832fa0f171861dfef07c