### PR TITLE
Fix lint issues

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -421,14 +421,14 @@ func evalIndex(scope *Scope, val interface{}, def int) (int, error) {
 		return def, nil
 	}
 	switch v := val.(type) {
+	case *Constantor:
+		return evalIndex(scope, v.Raw(), def)
 	case Runner:
 		r := v.Run(scope)
 		if _, ok := r.(*Invalidor); ok {
 			return 0, ErrEvalFail
 		}
 		return evalIndex(scope, r.Raw(), def)
-	case *Constantor:
-		return evalIndex(scope, v.Raw(), def)
 	case Pathor:
 		return evalIndex(scope, v.Raw(), def)
 	case string:

--- a/collections_test.go
+++ b/collections_test.go
@@ -271,7 +271,24 @@ func TestRange(t *testing.T) {
 				t.Errorf("unexpected result: %s", diff)
 			}
 		})
-  }
+	}
+}
+
+func TestRangeConstantor(t *testing.T) {
+	data := []int{0, 1, 2, 3}
+	r := Reflect(data).Find("", Range(Constant(1), Constant(3)))
+	if diff := cmp.Diff([]int{1, 2}, r.Raw()); diff != "" {
+		t.Errorf("unexpected result: %s", diff)
+	}
+}
+
+func TestRangeRunnerConstantor(t *testing.T) {
+	data := []string{"a", "b", "c", "d"}
+	var start Runner = Constant(1)
+	r := Reflect(data).Find("", Range(start, 3))
+	if diff := cmp.Diff([]string{"b", "c"}, r.Raw()); diff != "" {
+		t.Errorf("unexpected result: %s", diff)
+	}
 }
 
 func TestIndexConstantorPath(t *testing.T) {

--- a/jsonata/jsonata_test.go
+++ b/jsonata/jsonata_test.go
@@ -47,7 +47,9 @@ func TestJSONQueries(t *testing.T) {
 			Age  int    `json:"age"`
 		} `json:"users"`
 	}
-	json.Unmarshal(jsonData, &v)
+	if err := json.Unmarshal(jsonData, &v); err != nil {
+		t.Fatalf("failed to unmarshal json: %v", err)
+	}
 
 	assert.Equal(t, []int{7}, runQuery(t, v, "Users[Name='sam'].Age"))
 }


### PR DESCRIPTION
## Summary
- check json unmarshal errors in tests
- reorder interface checks to avoid unreachable case
- add tests covering Range with constantors

## Testing
- `go test ./...`
- `golangci-lint run | grep -E "json.Unmarshal|SA4020" || echo "none"`


------
https://chatgpt.com/codex/tasks/task_e_684ec24852d4832fa1405d17340646ea