### PR TITLE
Fix panic when calling Type on a nil Reflector

### DIFF
--- a/reflector.go
+++ b/reflector.go
@@ -17,6 +17,9 @@ func (r *Reflector) Path() string {
 
 // Type extracts the reflect.Type from the stored object
 func (r *Reflector) Type() reflect.Type {
+	if !r.v.IsValid() {
+		return nil
+	}
 	return r.v.Type()
 }
 

--- a/reflector_nil_test.go
+++ b/reflector_nil_test.go
@@ -1,0 +1,44 @@
+package lookup
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReflectNilTypeMethodsDoNotPanic(t *testing.T) {
+	p := Reflect(nil)
+
+	assertNoPanic := func(name string, fn func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s panicked for nil reflector: %v", name, r)
+			}
+		}()
+		fn()
+	}
+
+	assertNoPanic("IsNil", func() {
+		if !p.IsNil() {
+			t.Fatalf("expected IsNil() to be true")
+		}
+	})
+
+	assertNoPanic("IsString", func() {
+		if p.IsString() {
+			t.Fatalf("expected IsString() to be false")
+		}
+	})
+
+	assertNoPanic("AsString", func() {
+		if _, err := p.AsString(); err == nil || !errors.Is(err, ErrNotString) {
+			t.Fatalf("expected ErrNotString, got %v", err)
+		}
+	})
+
+	assertNoPanic("Type", func() {
+		if got := p.Type(); got != nil {
+			t.Fatalf("expected nil type for nil reflector, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
### Motivation
- Add an edge-case regression test to exercise `Reflect(nil)` behavior and ensure type-conversion helpers do not panic.
- Prevent runtime panics when calling `Type()` on a `Reflector` whose underlying `reflect.Value` is invalid.

### Description
- Added `reflector_nil_test.go` with `TestReflectNilTypeMethodsDoNotPanic` which asserts that `IsNil`, `IsString`, `AsString`, and `Type` do not panic for `Reflect(nil)` and that `Type()` returns `nil`.
- Updated `Reflector.Type()` in `reflector.go` to check `r.v.IsValid()` and return `nil` when the stored `reflect.Value` is invalid.

### Testing
- Ran `go test ./...` after the change and the test suite passed successfully.
- The new `TestReflectNilTypeMethodsDoNotPanic` was executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b2670504832fb494c4322bb65959)